### PR TITLE
Adds option to disable previews

### DIFF
--- a/src/Our.Umbraco.StackedContent/PropertyEditors/StackedContentPropertyEditor.cs
+++ b/src/Our.Umbraco.StackedContent/PropertyEditors/StackedContentPropertyEditor.cs
@@ -28,7 +28,8 @@ namespace Our.Umbraco.StackedContent.PropertyEditors
             {
                 {"contentTypes", ""},
                 {"maxItems", 0},
-                {"singleItemMode", "0"}
+                {"singleItemMode", "0"},
+                {"disablePreview", "0"}
             };
         }
 
@@ -52,6 +53,9 @@ namespace Our.Umbraco.StackedContent.PropertyEditors
 
             [PreValueField("hideLabel", "Hide Label", "boolean", Description = "Set whether to hide the editor label and have the list take up the full width of the editor window.")]
             public string HideLabel { get; set; }
+
+            [PreValueField("disablePreview", "Disable Preview", "boolean", Description = "Set whether to disable the preview of the items in the stack.")]
+            public string DisablePreview { get; set; }
         }
 
         #endregion

--- a/src/Our.Umbraco.StackedContent/Web/UI/App_Plugins/StackedContent/js/stackedcontent.controllers.js
+++ b/src/Our.Umbraco.StackedContent/Web/UI/App_Plugins/StackedContent/js/stackedcontent.controllers.js
@@ -64,6 +64,10 @@
             });
         }
 
+        var previewEnabled = function () {
+            return $scope.model.config.disablePreview !== "1";
+        }
+
         // Initialize
         innerContentService.getScaffolds($scope.model.config.contentTypes).then(function (scaffolds) {
 
@@ -82,11 +86,13 @@
                 callback: function (data) {
                     innerContentService.populateName(data.model, data.idx, $scope.model.config.contentTypes);
 
-                    scResources.getPreviewMarkup(data.model, editorState.current.id).then(function (markup) {
-                        if (markup) {
-                            $scope.markup[data.model.key] = markup;
-                        }
-                    });
+                    if (previewEnabled()) {
+                        scResources.getPreviewMarkup(data.model, editorState.current.id).then(function (markup) {
+                            if (markup) {
+                                $scope.markup[data.model.key] = markup;
+                            }
+                        });
+                    }
 
                     if (data.action === "add") {
                         $scope.model.value.splice(data.idx, 0, data.model);
@@ -115,7 +121,9 @@
                     });
 
                     // Try loading previews
-                    loadPreviews();
+                    if (previewEnabled()) {
+                        loadPreviews();
+                    }
                 });
 
             } else if ($scope.model.config.singleItemMode === "1") {
@@ -127,7 +135,9 @@
                 $scope.inited = true;
 
                 // Try loading previews
-                loadPreviews();
+                if (previewEnabled()) {
+                    loadPreviews();
+                }
 
             } else {
 


### PR DESCRIPTION
Implements feature request #4 

@mattbrailsford You happy with this JS for checking a false value?

    $scope.model.config.disablePreview !== "1"

I wasn't sure whether to use `previewEnabled` or `previewDisabled` as the functional name? (ended up thinking "enabled" was better)