### PR TITLE
Ensures the value is an array

### DIFF
--- a/src/Our.Umbraco.StackedContent/Web/UI/App_Plugins/StackedContent/js/stackedcontent.controllers.js
+++ b/src/Our.Umbraco.StackedContent/Web/UI/App_Plugins/StackedContent/js/stackedcontent.controllers.js
@@ -94,6 +94,10 @@
                         });
                     }
 
+                    if (!($scope.model.value instanceof Array)) {
+                        $scope.model.value = [];
+                    }
+
                     if (data.action === "add") {
                         $scope.model.value.splice(data.idx, 0, data.model);
                     } else if (data.action === "edit") {


### PR DESCRIPTION
When a validation error is triggered, it seems that the value is set to an empty string, so no longer an array.

Fixes #2