### PR TITLE
PropertyEditor group and icon

### DIFF
--- a/src/Our.Umbraco.StackedContent/PropertyEditors/StackedContentPropertyEditor.cs
+++ b/src/Our.Umbraco.StackedContent/PropertyEditors/StackedContentPropertyEditor.cs
@@ -9,7 +9,7 @@ using Umbraco.Core.Services;
 
 namespace Our.Umbraco.StackedContent.PropertyEditors
 {
-    [PropertyEditor(PropertyEditorAlias, "Stacked Content", "/App_Plugins/StackedContent/views/stackedcontent.html", ValueType = "JSON")]
+    [PropertyEditor(PropertyEditorAlias, "Stacked Content", "/App_Plugins/StackedContent/views/stackedcontent.html", Group = "rich content", Icon = "icon-umb-contour", ValueType = "JSON")]
     public class StackedContentPropertyEditor : PropertyEditor
     {
         public const string PropertyEditorAlias = "Our.Umbraco.StackedContent";


### PR DESCRIPTION
Added the property-editor to the "rich content" group (in the editor selection picker) and given it an icon.
(We were already re-using Contour's icon with the Add button, seems suitable)