### PR TITLE
adding type attribute to valueconverter.

### DIFF
--- a/src/Our.Umbraco.StackedContent/Converters/StackedContentValueConverter.cs
+++ b/src/Our.Umbraco.StackedContent/Converters/StackedContentValueConverter.cs
@@ -1,14 +1,18 @@
 ﻿using System;
+using System.Collections.Generic;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Our.Umbraco.InnerContent.Converters;
 using Our.Umbraco.StackedContent.PropertyEditors;
 using Umbraco.Core;
 using Umbraco.Core.Logging;
+using Umbraco.Core.Models;
 using Umbraco.Core.Models.PublishedContent;
+using Umbraco.Core.PropertyEditors;
 
 namespace Our.Umbraco.StackedContent.Converters
 {
+    [PropertyValueType(typeof(IEnumerable<IPublishedContent>))]
     public class StackedContentValueConverter : InnerContentValueConverter
     {
         public override bool IsConverter(PublishedPropertyType propertyType)


### PR DESCRIPTION
Not sure if there's a reason for this attribute not being added - otherwise I'd like it to be there so I won't have to cast it when using the valueconverter :)