### PR TITLE
Copy and paste

### DIFF
--- a/src/Our.Umbraco.StackedContent/Web/UI/App_Plugins/StackedContent/css/stackedcontent.css
+++ b/src/Our.Umbraco.StackedContent/Web/UI/App_Plugins/StackedContent/css/stackedcontent.css
@@ -141,6 +141,7 @@
 
 .stack__button,
 .stack__add-button,
+.stack__paste-button,
 .stack__buttons .umb_confirm-action__overlay-action {
     display: inline-block;
     background-color: #2e8aea;
@@ -156,6 +157,7 @@
 
 .stack__button:hover,
 .stack__add-button:hover,
+.stack__paste-button:hover,
 .stack__buttons .umb_confirm-action__overlay-action.-cancel:hover,
 .stack__buttons .umb_confirm-action__overlay-action.-confirm:hover {
     color: white !important;
@@ -170,7 +172,8 @@
     background-color: #e74c3c;
 }
 
-.stack__add-button {
+.stack__add-button,
+.stack__paste-button {
     -webkit-border-radius: 2px;
     -moz-border-radius: 2px;
     border-radius: 2px;
@@ -181,13 +184,11 @@
     position: relative;
     height: 10px;
     z-index: 15;
+    text-align: center;
 }
 
-.stack__add-bar .stack__add-button {
-    position: absolute;
-    left: 50%;
-    top: 50%;
-    margin: -15px 0 0 -15px;
+.stack__add-bar .stack__add-button,
+.stack__add-bar .stack__paste-button {
     opacity: 0;
     transition: opacity .0s ease-in-out;
     -moz-transition: opacity .0s ease-in-out;
@@ -207,7 +208,8 @@
     height: 20px;
 }
 
-.stack__add-bar:hover .stack__add-button {
+.stack__add-bar:hover .stack__add-button,
+.stack__add-bar:hover .stack__paste-button {
     opacity: 1;
     transition-duration: .25s;
     -moz-transition-duration: .25s;

--- a/src/Our.Umbraco.StackedContent/Web/UI/App_Plugins/StackedContent/js/stackedcontent.controllers.js
+++ b/src/Our.Umbraco.StackedContent/Web/UI/App_Plugins/StackedContent/js/stackedcontent.controllers.js
@@ -77,9 +77,7 @@
                 return;
             }
             if (validateModel(stackedContentItem)) {
-                $scope.overlayConfig.event = evt;
-                $scope.overlayConfig.data = { model: stackedContentItem, idx: idx, action: "add" };
-                $scope.overlayConfig.show = true;
+                $scope.overlayConfig.callback({ model: stackedContentItem, idx: idx, action: "add" });
                 return;
             } else {
                 notificationsService.error("Stacked Content", "Sorry, this content is not allowed here.");

--- a/src/Our.Umbraco.StackedContent/Web/UI/App_Plugins/StackedContent/js/stackedcontent.controllers.js
+++ b/src/Our.Umbraco.StackedContent/Web/UI/App_Plugins/StackedContent/js/stackedcontent.controllers.js
@@ -127,8 +127,8 @@
 
         var validateModel = function (model) {
             try {
-                if (!model || !model.icContentTypeAlias) return false;
-                if (!$scope.model.config.contentTypes.filter(x => x.icContentTypeAlias === model.icContentTypeAlias).length) return false;
+                if (!model || !model.icContentTypeGuid) return false;
+                if (!$scope.model.config.contentTypes.filter(x => x.icContentTypeGuid === model.icContentTypeGuid).length) return false;
                 return true;
             } catch (e) {
                 return false;

--- a/src/Our.Umbraco.StackedContent/Web/UI/App_Plugins/StackedContent/js/stackedcontent.controllers.js
+++ b/src/Our.Umbraco.StackedContent/Web/UI/App_Plugins/StackedContent/js/stackedcontent.controllers.js
@@ -56,9 +56,9 @@
         }
 
         $scope.copyToLocalStorage = function (evt, idx) {
-            var stackedContentItem = angular.extend({}, $scope.model.value[idx]);
+            var stackedContentItem = JSON.parse(JSON.stringify($scope.model.value[idx]));
             stackedContentItem.key = "";
-            stackedContentItem.$$hashKey = "";
+            delete stackedContentItem.$$hashKey;
 
             if (validateModel(stackedContentItem)) {
                 window.localStorage.setItem("StackedContentCopy", JSON.stringify(stackedContentItem));
@@ -71,6 +71,7 @@
 
         $scope.pasteFromLocalStorage = function (evt, idx) {
             var stackedContentItem = JSON.parse(window.localStorage.getItem("StackedContentCopy"));
+            stackedContentItem.key = innerContentService.generateUid();
             if (!stackedContentItem) {
                 notificationsService.error("Stacked Content", "You need to copy content first.");
                 return;

--- a/src/Our.Umbraco.StackedContent/Web/UI/App_Plugins/StackedContent/js/stackedcontent.controllers.js
+++ b/src/Our.Umbraco.StackedContent/Web/UI/App_Plugins/StackedContent/js/stackedcontent.controllers.js
@@ -21,6 +21,17 @@
             return $scope.model.config.singleItemMode !== "1";
         }
 
+        $scope.canCopy = function () {
+            var test = "test";
+            try {
+                window.localStorage.setItem(test, test);
+                window.localStorage.removeItem(test);
+                return true;
+            } catch (e) {
+                return false;
+            }
+		}
+
         $scope.canPaste = function () {
             var stackedContentItem = JSON.parse(window.localStorage.getItem("StackedContentCopy"));
             if (stackedContentItem && validateModel(stackedContentItem)) return true;
@@ -107,7 +118,6 @@
 
         var validateModel = function (model) {
             try {
-                console.log($scope.model.config.contentTypes);
                 if (!model || !model.icContentTypeAlias) return false;
                 if (!$scope.model.config.contentTypes.filter(x => x.icContentTypeAlias === model.icContentTypeAlias).length) return false;
                 return true;

--- a/src/Our.Umbraco.StackedContent/Web/UI/App_Plugins/StackedContent/js/stackedcontent.controllers.js
+++ b/src/Our.Umbraco.StackedContent/Web/UI/App_Plugins/StackedContent/js/stackedcontent.controllers.js
@@ -55,7 +55,7 @@
         }
 
         $scope.copyToLocalStorage = function (evt, idx) {
-            var stackedContentItem = Object.assign({}, $scope.model.value[idx]);
+            var stackedContentItem = angular.extend({}, $scope.model.value[idx]);
             stackedContentItem.key = "";
             stackedContentItem.$$hashKey = "";
 

--- a/src/Our.Umbraco.StackedContent/Web/UI/App_Plugins/StackedContent/views/stackedcontent.html
+++ b/src/Our.Umbraco.StackedContent/Web/UI/App_Plugins/StackedContent/views/stackedcontent.html
@@ -33,7 +33,7 @@
                                                     on-cancel="prompts[itm.key] = false">
                                 </umb-confirm-action>
                                 <a ng-click="prompts[itm.key] = true" class="stack__button" title="Delete"><i class="icon icon-trash"></i></a>
-                                <a ng-click="copyToLocalStorage($event, $index)" class="stack__button" title="Copy"><i class="icon icon-documents"></i></a>
+                                <a ng-click="copyToLocalStorage($event, $index)" ng-if="canCopy()" class="stack__button" title="Copy"><i class="icon icon-documents"></i></a>
                             </div>
                         </div>
                     </div>

--- a/src/Our.Umbraco.StackedContent/Web/UI/App_Plugins/StackedContent/views/stackedcontent.html
+++ b/src/Our.Umbraco.StackedContent/Web/UI/App_Plugins/StackedContent/views/stackedcontent.html
@@ -14,7 +14,8 @@
 
                 <div class="stack__item" ng-repeat="itm in model.value">
                     <div class="stack__add-bar stack__add-bar--top" ng-if="model.config.singleItemMode !== '1'">
-                        <a ng-click="addContent($event, $index)" class="stack__add-button" ng-if="canAdd()"><i class="icon icon-add"></i></a>
+                        <a ng-click="addContent($event, $index)" class="stack__add-button" ng-if="canAdd()" title="Add"><i class="icon icon-add"></i></a>
+                        <a ng-click="pasteFromLocalStorage($event, $index)" class="stack__paste-button" ng-if="canPaste()" title="Paste"><i class="icon icon-documents"></i></a>
                     </div>
                     <div class="stack__preview-wrapper">
                         <a ng-click="editContent($event, $index, itm)" class="stack__preview stack__preview--default" ng-if="!markup[itm.key]">
@@ -31,7 +32,8 @@
                                                     on-confirm="deleteContent($event, $index)"
                                                     on-cancel="prompts[itm.key] = false">
                                 </umb-confirm-action>
-                                <a ng-click="prompts[itm.key] = true" class="stack__button"><i class="icon icon-trash"></i></a>
+                                <a ng-click="prompts[itm.key] = true" class="stack__button" title="Delete"><i class="icon icon-trash"></i></a>
+                                <a ng-click="copyToLocalStorage($event, $index)" class="stack__button" title="Copy"><i class="icon icon-documents"></i></a>
                             </div>
                         </div>
                     </div>
@@ -40,7 +42,8 @@
             </div>
 
             <div class="stack__add-bar stack__add-bar--bottom" ng-if="model.config.singleItemMode !== '1'">
-                <a ng-click="addContent($event, model.value.length)" class="stack__add-button" ng-if="canAdd()"><i class="icon icon-add"></i></a>
+                <a ng-click="addContent($event, model.value.length)" class="stack__add-button" ng-if="canAdd()" title="Add"><i class="icon icon-add"></i></a>
+                <a ng-click="pasteFromLocalStorage($event, model.value.length)" class="stack__paste-button" ng-if="canPaste()" title="Paste"><i class="icon icon-documents"></i></a>
             </div>
 
         </div>

--- a/src/Our.Umbraco.StackedContent/Web/UI/App_Plugins/StackedContent/views/stackedcontent.html
+++ b/src/Our.Umbraco.StackedContent/Web/UI/App_Plugins/StackedContent/views/stackedcontent.html
@@ -27,13 +27,13 @@
                         </a>
                         <div class="stack__buttons" ng-if="canDelete()" ng-mousedown="$event.stopPropagation();">
                             <div class="no-overflow">
+                                <a ng-click="copyToLocalStorage($event, $index)" ng-if="canCopy()" class="stack__button" title="Copy"><i class="icon icon-documents"></i></a>
                                 <umb-confirm-action ng-if="prompts[itm.key]"
                                                     direction="left"
                                                     on-confirm="deleteContent($event, $index)"
                                                     on-cancel="prompts[itm.key] = false">
                                 </umb-confirm-action>
                                 <a ng-click="prompts[itm.key] = true" class="stack__button" title="Delete"><i class="icon icon-trash"></i></a>
-                                <a ng-click="copyToLocalStorage($event, $index)" ng-if="canCopy()" class="stack__button" title="Copy"><i class="icon icon-documents"></i></a>
                             </div>
                         </div>
                     </div>

--- a/src/Our.Umbraco.StackedContent/Web/UI/App_Plugins/StackedContent/views/stackedcontent.html
+++ b/src/Our.Umbraco.StackedContent/Web/UI/App_Plugins/StackedContent/views/stackedcontent.html
@@ -15,7 +15,7 @@
                 <div class="stack__item" ng-repeat="itm in model.value">
                     <div class="stack__add-bar stack__add-bar--top" ng-if="model.config.singleItemMode !== '1'">
                         <a ng-click="addContent($event, $index)" class="stack__add-button" ng-if="canAdd()" title="Add"><i class="icon icon-add"></i></a>
-                        <a ng-click="pasteFromLocalStorage($event, $index)" class="stack__paste-button" ng-if="canPaste()" title="Paste"><i class="icon icon-documents"></i></a>
+                        <a ng-click="pasteFromLocalStorage($event, $index)" class="stack__paste-button" ng-if="canPaste()" title="Paste"><i class="icon icon-paste-in"></i></a>
                     </div>
                     <div class="stack__preview-wrapper">
                         <a ng-click="editContent($event, $index, itm)" class="stack__preview stack__preview--default" ng-if="!markup[itm.key]">
@@ -27,7 +27,7 @@
                         </a>
                         <div class="stack__buttons" ng-if="canDelete()" ng-mousedown="$event.stopPropagation();">
                             <div class="no-overflow">
-                                <a ng-click="copyToLocalStorage($event, $index)" ng-if="canCopy()" class="stack__button" title="Copy"><i class="icon icon-documents"></i></a>
+								<a ng-click="copyToLocalStorage($event, $index)" ng-if="canCopy()" class="stack__button" title="Copy"><i class="icon icon-documents"></i></a>
                                 <umb-confirm-action ng-if="prompts[itm.key]"
                                                     direction="left"
                                                     on-confirm="deleteContent($event, $index)"
@@ -43,7 +43,7 @@
 
             <div class="stack__add-bar stack__add-bar--bottom" ng-if="model.config.singleItemMode !== '1'">
                 <a ng-click="addContent($event, model.value.length)" class="stack__add-button" ng-if="canAdd()" title="Add"><i class="icon icon-add"></i></a>
-                <a ng-click="pasteFromLocalStorage($event, model.value.length)" class="stack__paste-button" ng-if="canPaste()" title="Paste"><i class="icon icon-documents"></i></a>
+                <a ng-click="pasteFromLocalStorage($event, model.value.length)" class="stack__paste-button" ng-if="canPaste()" title="Paste"><i class="icon icon-paste-in"></i></a>
             </div>
 
         </div>


### PR DESCRIPTION
The following pull request is a result of the discussion of Issue #25. This allows a content author in the back office to copy any stacked content item and paste the stacked content item as many times as they wish. This solution takes advantage of `window.localStorage` to copy the item - so the author can actually paste across content nodes!

**Noteworthy updates:**

- A `copy` button has been added and placed directly next to the _delete button_.
  - Supporting functions: `canCopy()` and `copyToLocalStorage()`.
- A `paste` button has been added and placed directly next to the _add button(s)_.
  - Supporting functions: `canPaste()` and `validateModel()` and `pasteFromLocalStorage()`.
- The `title` attribute was added to these buttons.
- Notifications Service added to the controller and messages have been provided for the following events:
  - Copy event succeeded.
  - Copy event failed.
  - Paste event when no content was found. _Should never occur._
  - Paste event if the doc type (copied) is not currently allowed.
 
**Remaining concerns:**

1. On initial load stacked content shows a larger add button (referenced to as placeholder in CSS). I didn't modify the initial state of stacked content, when nothing has been added. So there is no way to paste until an item is already there. 
2. Just realizing that I used `Object.Assign()` and we should provide a polyfill for this functionality, or use `jQuery.extend()` to resolve immediately.

**Supporting screenshots:**

![image](https://user-images.githubusercontent.com/713355/35446583-2ba1ee48-0283-11e8-9530-69fd97e0c620.png)
![image](https://user-images.githubusercontent.com/713355/35446630-5114017a-0283-11e8-937c-a3c22f22bdcf.png)
![image](https://user-images.githubusercontent.com/713355/35446674-80901808-0283-11e8-977e-be2295dbd1e7.png)
![image](https://user-images.githubusercontent.com/713355/35446711-990ed77a-0283-11e8-814b-f2c68f7fb03e.png)
![image](https://user-images.githubusercontent.com/713355/35446729-ac0e376c-0283-11e8-9cec-28eafd20a66a.png)