### PR TITLE
Adds migration for v1.1.0

### DIFF
--- a/src/Our.Umbraco.StackedContent/Bootstrap.cs
+++ b/src/Our.Umbraco.StackedContent/Bootstrap.cs
@@ -1,0 +1,43 @@
+﻿using System.Diagnostics;
+using System.Reflection;
+using Our.Umbraco.InnerContent.Helpers;
+using Our.Umbraco.StackedContent.PropertyEditors;
+using Semver;
+using Umbraco.Core;
+
+namespace Our.Umbraco.StackedContent
+{
+    public class Bootstrap : ApplicationEventHandler
+    {
+        protected override void ApplicationStarted(UmbracoApplicationBase umbracoApplication, ApplicationContext applicationContext)
+        {
+            ApplyMigrations(applicationContext);
+        }
+
+        private void ApplyMigrations(ApplicationContext applicationContext)
+        {
+            var productName = StackedContentPropertyEditor.PropertyEditorAlias;
+            var currentVersion = new SemVersion(0, 0, 0);
+            var targetVersion = GetApplicationVersion();
+
+            MigrationHelper.ApplyMigrations(applicationContext, productName, currentVersion, targetVersion);
+        }
+
+        private SemVersion GetApplicationVersion()
+        {
+            var assembly = Assembly.GetExecutingAssembly();
+            if (assembly != null)
+            {
+                var info = FileVersionInfo.GetVersionInfo(assembly.Location);
+                if (info != null
+                    && string.IsNullOrWhiteSpace(info.ProductVersion) == false
+                    && SemVersion.TryParse(info.ProductVersion, out SemVersion applicationVersion))
+                {
+                    return applicationVersion;
+                }
+            }
+
+            return new SemVersion(0, 0, 0);
+        }
+    }
+}

--- a/src/Our.Umbraco.StackedContent/Bootstrap.cs
+++ b/src/Our.Umbraco.StackedContent/Bootstrap.cs
@@ -1,8 +1,4 @@
-﻿using System.Diagnostics;
-using System.Reflection;
-using Our.Umbraco.InnerContent.Helpers;
-using Our.Umbraco.StackedContent.PropertyEditors;
-using Semver;
+﻿using Our.Umbraco.StackedContent.Migrations;
 using Umbraco.Core;
 
 namespace Our.Umbraco.StackedContent
@@ -11,33 +7,7 @@ namespace Our.Umbraco.StackedContent
     {
         protected override void ApplicationStarted(UmbracoApplicationBase umbracoApplication, ApplicationContext applicationContext)
         {
-            ApplyMigrations(applicationContext);
-        }
-
-        private void ApplyMigrations(ApplicationContext applicationContext)
-        {
-            var productName = StackedContentPropertyEditor.PropertyEditorAlias;
-            var currentVersion = new SemVersion(0, 0, 0);
-            var targetVersion = GetApplicationVersion();
-
-            MigrationHelper.ApplyMigrations(applicationContext, productName, currentVersion, targetVersion);
-        }
-
-        private SemVersion GetApplicationVersion()
-        {
-            var assembly = Assembly.GetExecutingAssembly();
-            if (assembly != null)
-            {
-                var info = FileVersionInfo.GetVersionInfo(assembly.Location);
-                if (info != null
-                    && string.IsNullOrWhiteSpace(info.ProductVersion) == false
-                    && SemVersion.TryParse(info.ProductVersion, out SemVersion applicationVersion))
-                {
-                    return applicationVersion;
-                }
-            }
-
-            return new SemVersion(0, 0, 0);
+            MigrationHelper.ApplyMigrations(applicationContext);
         }
     }
 }

--- a/src/Our.Umbraco.StackedContent/Migrations/MigrationHelper.cs
+++ b/src/Our.Umbraco.StackedContent/Migrations/MigrationHelper.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+using System.Web;
+using Our.Umbraco.StackedContent.PropertyEditors;
+using Semver;
+using Umbraco.Core;
+using Umbraco.Core.Logging;
+using Umbraco.Core.Persistence;
+using Umbraco.Core.Persistence.Migrations;
+
+namespace Our.Umbraco.StackedContent.Migrations
+{
+    internal static class MigrationHelper
+    {
+        public static void ApplyMigrations(ApplicationContext applicationContext)
+        {
+            var migrationName = StackedContentPropertyEditor.PropertyEditorAlias;
+            var currentVersion = new SemVersion(0, 0, 0);
+            var targetVersion = GetApplicationVersion();
+
+            // get the latest migration executed
+            var latestMigration = applicationContext.Services.MigrationEntryService
+                .GetAll(migrationName)
+                .OrderByDescending(x => x.Version)
+                .FirstOrDefault();
+
+            if (latestMigration != null)
+                currentVersion = latestMigration.Version;
+
+            if (targetVersion == currentVersion)
+                return;
+
+            var migrationsRunner = new MigrationRunner(
+                applicationContext.Services.MigrationEntryService,
+                applicationContext.ProfilingLogger.Logger,
+                currentVersion,
+                targetVersion,
+                migrationName);
+
+            try
+            {
+                migrationsRunner.Execute(applicationContext.DatabaseContext.Database);
+            }
+            catch (HttpException)
+            {
+                // because umbraco runs some other migrations after the migration runner
+                // is executed we get HttpException
+                // catch this error, but don't do anything
+                // fixed in 7.4.2+ see : http://issues.umbraco.org/issue/U4-8077
+            }
+            catch (Exception ex)
+            {
+                LogHelper.Error<MigrationRunner>("Error running migration.", ex);
+            }
+        }
+
+        private static SemVersion GetApplicationVersion()
+        {
+            var assembly = Assembly.GetExecutingAssembly();
+            if (assembly != null)
+            {
+                var info = FileVersionInfo.GetVersionInfo(assembly.Location);
+                if (info != null
+                    && string.IsNullOrWhiteSpace(info.ProductVersion) == false
+                    && SemVersion.TryParse(info.ProductVersion, out SemVersion applicationVersion))
+                {
+                    return applicationVersion;
+                }
+            }
+
+            return new SemVersion(0, 0, 0);
+        }
+    }
+}

--- a/src/Our.Umbraco.StackedContent/Migrations/TargetOneOneZero/UpdateDataTypes.cs
+++ b/src/Our.Umbraco.StackedContent/Migrations/TargetOneOneZero/UpdateDataTypes.cs
@@ -1,0 +1,88 @@
+﻿using Newtonsoft.Json;
+using Our.Umbraco.StackedContent.PropertyEditors;
+using Umbraco.Core;
+using Umbraco.Core.Logging;
+using Umbraco.Core.Persistence.Migrations;
+using Umbraco.Core.Persistence.SqlSyntax;
+
+namespace Our.Umbraco.StackedContent.Migrations.TargetOneOneZero
+{
+    [Migration("1.1.0", 1, StackedContentPropertyEditor.PropertyEditorAlias)]
+    public class UpdateDataTypes : MigrationBase
+    {
+        public UpdateDataTypes(ISqlSyntaxProvider sqlSyntax, ILogger logger)
+            : base(sqlSyntax, logger)
+        { }
+
+        public override void Down()
+        { }
+
+        public override void Up()
+        {
+            var contentTypeService = ApplicationContext.Current.Services.ContentTypeService;
+            var dataTypeService = ApplicationContext.Current.Services.DataTypeService;
+
+            // Find all the StackedContent data-types
+            var dataTypes = dataTypeService.GetDataTypeDefinitionByPropertyEditorAlias(StackedContentPropertyEditor.PropertyEditorAlias);
+            if (dataTypes == null)
+                return;
+
+            foreach (var dataType in dataTypes)
+            {
+                var requiresSave = false;
+
+                var preValues = dataTypeService.GetPreValuesCollectionByDataTypeId(dataType.Id);
+                if (preValues == null)
+                    continue;
+
+                var config = preValues.PreValuesAsDictionary;
+                if (config.ContainsKey("contentTypes"))
+                {
+                    // Get all the saved doc-type aliases
+                    var contentTypes = config["contentTypes"];
+                    var json = contentTypes.Value;
+                    if (string.IsNullOrWhiteSpace(json))
+                        continue;
+
+                    // Replace the doc-type alias with the doc-type GUID
+                    var options = JsonConvert.DeserializeObject<ContentTypeOption[]>(json);
+                    if (options == null)
+                        continue;
+
+                    foreach (var option in options)
+                    {
+                        // If the prevalue already has a GUID, then skip it
+                        if (string.IsNullOrWhiteSpace(option.icContentTypeGuid) == false)
+                            continue;
+
+                        if (string.IsNullOrWhiteSpace(option.icContentTypeAlias))
+                            continue;
+
+                        var docType = contentTypeService.GetContentType(option.icContentTypeAlias);
+                        if (docType == null)
+                            continue;
+
+                        option.icContentTypeGuid = docType.Key.ToString();
+                        requiresSave = true;
+                    }
+
+                    // Save the prevalue and data-type
+                    if (requiresSave)
+                    {
+                        contentTypes.Value = JsonConvert.SerializeObject(options);
+                        dataTypeService.SaveDataTypeAndPreValues(dataType, config);
+                    }
+                }
+            }
+        }
+
+#pragma warning disable IDE1006 // Naming Styles
+        public class ContentTypeOption
+        {
+            public string icContentTypeAlias { get; set; }
+            public string icContentTypeGuid { get; set; }
+            public string nameTemplate { get; set; }
+        }
+#pragma warning restore IDE1006 // Naming Styles
+    }
+}

--- a/src/Our.Umbraco.StackedContent/Migrations/TargetOneOneZero/UpdateDataTypes.cs
+++ b/src/Our.Umbraco.StackedContent/Migrations/TargetOneOneZero/UpdateDataTypes.cs
@@ -63,6 +63,7 @@ namespace Our.Umbraco.StackedContent.Migrations.TargetOneOneZero
                             continue;
 
                         option.icContentTypeGuid = docType.Key.ToString();
+                        option.icContentTypeAlias = null;
                         requiresSave = true;
                     }
 
@@ -79,6 +80,7 @@ namespace Our.Umbraco.StackedContent.Migrations.TargetOneOneZero
 #pragma warning disable IDE1006 // Naming Styles
         public class ContentTypeOption
         {
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
             public string icContentTypeAlias { get; set; }
             public string icContentTypeGuid { get; set; }
             public string nameTemplate { get; set; }

--- a/src/Our.Umbraco.StackedContent/Migrations/TargetOneOneZero/UpdatePropertyData.cs
+++ b/src/Our.Umbraco.StackedContent/Migrations/TargetOneOneZero/UpdatePropertyData.cs
@@ -1,0 +1,104 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Our.Umbraco.StackedContent.PropertyEditors;
+using Umbraco.Core;
+using Umbraco.Core.Logging;
+using Umbraco.Core.Persistence;
+using Umbraco.Core.Persistence.Migrations;
+using Umbraco.Core.Persistence.SqlSyntax;
+
+namespace Our.Umbraco.StackedContent.Migrations.TargetOneOneZero
+{
+    [Migration("1.1.0", 2, StackedContentPropertyEditor.PropertyEditorAlias)]
+    public class UpdatePropertyData : MigrationBase
+    {
+        public UpdatePropertyData(ISqlSyntaxProvider sqlSyntax, ILogger logger)
+            : base(sqlSyntax, logger)
+        { }
+
+        public override void Down()
+        { }
+
+        public override void Up()
+        {
+            var context = ApplicationContext.Current.DatabaseContext;
+            if (context.IsDatabaseConfigured == false)
+                return;
+
+            var db = context.Database;
+
+            // get the patterns/replacements (e.g. the doctypes alias and guid replacement)
+            var patterns = GetContentTypeRegexPatterns(db);
+
+            // get all the property-data that has "icContentTypeAlias"
+            var rows = GetPropertyDataRows(db);
+
+            // loop over the property data
+            foreach (var row in rows)
+            {
+                // loop over each pattern/replacement
+                foreach (var pattern in patterns)
+                {
+                    // perform a regex replace against the property-data for each doctype alias
+                    row.dataNtext = Regex.Replace(row.dataNtext, pattern.Key, pattern.Value);
+                }
+
+                // save back to database (transactional)
+                using (var transaction = db.GetTransaction())
+                {
+                    db.Execute("UPDATE [cmsPropertyData] SET [dataNtext] = @0 WHERE [id] = @1", row.dataNtext, row.id);
+                    transaction.Complete();
+                }
+            }
+        }
+
+        private Dictionary<string, string> GetContentTypeRegexPatterns(UmbracoDatabase db)
+        {
+            var sql = @"
+SELECT DISTINCT
+    ct.alias,
+    LOWER(n.uniqueID) AS [uniqueID]
+FROM
+    cmsContentType AS ct
+    INNER JOIN umbracoNode AS n ON n.id = ct.nodeId
+    INNER JOIN cmsDataTypePreValues AS dtpv ON dtpv.[value] LIKE '%""icContentTypeAlias"": ""' + ct.alias + '""%'
+    INNER JOIN cmsDataType AS dt ON dt.nodeId = dtpv.datatypeNodeId
+WHERE
+    dt.propertyEditorAlias = '@0' AND dtpv.alias = 'contentTypes'
+;";
+            return db
+                .Query<ContentTypeDto>(sql, StackedContentPropertyEditor.PropertyEditorAlias)
+                .ToDictionary(
+                    x => $"\"icContentTypeAlias([\\\\\"]*):([\\\\\"]*){x.alias}([\\\\\"]*)",
+                    x => $"\"icContentTypeGuid${{1}}:${{2}}{x.uniqueID}$3");
+        }
+
+        private IEnumerable<PropertyDataDto> GetPropertyDataRows(UmbracoDatabase db)
+        {
+            var sql = @"
+SELECT
+    pd.id,
+    pd.dataNtext
+FROM
+    cmsPropertyData AS pd
+    INNER JOIN cmsDocument AS d ON d.versionId = pd.versionId
+WHERE
+    d.newest = 1 AND pd.dataNtext LIKE '%icContentTypeAlias%:%'
+;";
+            return db.Query<PropertyDataDto>(sql);
+        }
+
+        private class ContentTypeDto
+        {
+            public string alias { get; set; }
+            public string uniqueID { get; set; }
+        }
+
+        private class PropertyDataDto
+        {
+            public int id { get; set; }
+            public string dataNtext { get; set; }
+        }
+    }
+}

--- a/src/Our.Umbraco.StackedContent/Our.Umbraco.StackedContent.csproj
+++ b/src/Our.Umbraco.StackedContent/Our.Umbraco.StackedContent.csproj
@@ -261,6 +261,7 @@
     <Compile Include="Bootstrap.cs" />
     <Compile Include="Converters\StackedContentValueConverter.cs" />
     <Compile Include="Migrations\TargetOneOneZero\UpdateDataTypes.cs" />
+    <Compile Include="Migrations\TargetOneOneZero\UpdatePropertyData.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\VersionInfo.cs" />
     <Compile Include="PropertyEditors\StackedContentPropertyEditor.cs" />

--- a/src/Our.Umbraco.StackedContent/Our.Umbraco.StackedContent.csproj
+++ b/src/Our.Umbraco.StackedContent/Our.Umbraco.StackedContent.csproj
@@ -258,7 +258,9 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Bootstrap.cs" />
     <Compile Include="Converters\StackedContentValueConverter.cs" />
+    <Compile Include="Migrations\TargetOneOneZero\UpdateDataTypes.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\VersionInfo.cs" />
     <Compile Include="PropertyEditors\StackedContentPropertyEditor.cs" />

--- a/src/Our.Umbraco.StackedContent/Our.Umbraco.StackedContent.csproj
+++ b/src/Our.Umbraco.StackedContent/Our.Umbraco.StackedContent.csproj
@@ -260,6 +260,7 @@
   <ItemGroup>
     <Compile Include="Bootstrap.cs" />
     <Compile Include="Converters\StackedContentValueConverter.cs" />
+    <Compile Include="Migrations\MigrationHelper.cs" />
     <Compile Include="Migrations\TargetOneOneZero\UpdateDataTypes.cs" />
     <Compile Include="Migrations\TargetOneOneZero\UpdatePropertyData.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
When upgrading to (upcoming) StackedContent (and InnerContent) v1.1.0, the user would need to re-save all the StackedContent data-types, in order to swap over the doc-type aliases with GUIDs.

This migration would automate that step.

> **Note:** This pull request depends on a pull request in the InnerContent repository: https://github.com/umco/umbraco-inner-content/pull/12

---

I'd considered attempting to tackle property-data, but fear took the better of me - the thought of vorto'd-nested-gridified-stacked-contents scared me shitless! 😝 