### PR TITLE
Ensures ContentType GUIDs

### DIFF
--- a/src/Our.Umbraco.StackedContent/Our.Umbraco.StackedContent.csproj
+++ b/src/Our.Umbraco.StackedContent/Our.Umbraco.StackedContent.csproj
@@ -146,9 +146,8 @@
       <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="Our.Umbraco.InnerContent, Version=1.0.6286.21529, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Our.Umbraco.InnerContent.Core.1.0.3\lib\net45\Our.Umbraco.InnerContent.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="Our.Umbraco.InnerContent, Version=1.1.6638.5280, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Our.Umbraco.InnerContent.Core.1.1.0\lib\net45\Our.Umbraco.InnerContent.dll</HintPath>
     </Reference>
     <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">
       <HintPath>..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>

--- a/src/Our.Umbraco.StackedContent/PropertyEditors/StackedContentPropertyEditor.cs
+++ b/src/Our.Umbraco.StackedContent/PropertyEditors/StackedContentPropertyEditor.cs
@@ -23,9 +23,6 @@ namespace Our.Umbraco.StackedContent.PropertyEditors
 
         internal class StackedContentPreValueEditor : SimpleInnerContentPreValueEditor
         {
-            [PreValueField("contentTypes", "Content Types", "~/App_Plugins/InnerContent/views/innercontent.doctypepicker.html", Description = "Select the content types to use as the data blueprint.")]
-            public new string[] ContentTypes { get; set; }
-
             [PreValueField("maxItems", "Max Items", "number", Description = "Set the maximum number of items allowed in this stack.")]
             public string MaxItems { get; set; }
 

--- a/src/Our.Umbraco.StackedContent/PropertyEditors/StackedContentPropertyEditor.cs
+++ b/src/Our.Umbraco.StackedContent/PropertyEditors/StackedContentPropertyEditor.cs
@@ -1,146 +1,15 @@
-﻿using System.Collections.Generic;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+﻿using Umbraco.Core.PropertyEditors;
 using Our.Umbraco.InnerContent.PropertyEditors;
-using Umbraco.Core;
-using Umbraco.Core.Models;
-using Umbraco.Core.PropertyEditors;
-using Umbraco.Core.Services;
 
 namespace Our.Umbraco.StackedContent.PropertyEditors
 {
     [PropertyEditor(PropertyEditorAlias, "Stacked Content", "/App_Plugins/StackedContent/views/stackedcontent.html", Group = "rich content", Icon = "icon-umb-contour", ValueType = "JSON")]
-    public class StackedContentPropertyEditor : PropertyEditor
+    public class StackedContentPropertyEditor : SimpleInnerContentPropertyEditor
     {
         public const string PropertyEditorAlias = "Our.Umbraco.StackedContent";
 
-        private IDictionary<string, object> _defaultPreValues;
-        public override IDictionary<string, object> DefaultPreValues
-        {
-            get { return _defaultPreValues; }
-            set { _defaultPreValues = value; }
-        }
-
         public StackedContentPropertyEditor()
-        {
-            // Setup default values
-            _defaultPreValues = new Dictionary<string, object>
-            {
-                { "contentTypes", "" },
-                { "maxItems", 0 },
-                { "singleItemMode", "0" },
-                { "disablePreview", "0" }
-            };
-        }
-
-        internal static bool TryEnsureContentTypeGuids(JArray items, IContentTypeService contentTypeService)
-        {
-            if (items == null)
-                return false;
-
-            var persist = false;
-
-            foreach (var item in items)
-            {
-                var contentTypeGuid = item["icContentTypeGuid"];
-                if (contentTypeGuid != null)
-                    continue;
-
-                var contentTypeAlias = item["icContentTypeAlias"];
-                if (contentTypeAlias == null)
-                    continue;
-
-                var docType = contentTypeService.GetContentType(contentTypeAlias.Value<string>());
-                if (docType == null)
-                    continue;
-
-                item["icContentTypeGuid"] = docType.Key.ToString();
-                persist = true;
-            }
-
-            return persist;
-        }
-
-        #region Pre Value Editor
-
-        protected override PreValueEditor CreatePreValueEditor()
-        {
-            return new StackPreValueEditor();
-        }
-
-        internal class StackPreValueEditor : PreValueEditor
-        {
-            [PreValueField("contentTypes", "Doc Types", "~/App_Plugins/InnerContent/views/innercontent.doctypepicker.html", Description = "Select the doc types to use as the data blueprint.")]
-            public string[] ContentTypes { get; set; }
-
-            [PreValueField("maxItems", "Max Items", "number", Description = "Set the maximum number of items allowed in this stack.")]
-            public string MaxItems { get; set; }
-
-            [PreValueField("singleItemMode", "Single Item Mode", "boolean", Description = "Set whether to work in single item mode (only the first defined Doc Type will be used).")]
-            public string SingleItemMode { get; set; }
-
-            [PreValueField("hideLabel", "Hide Label", "boolean", Description = "Set whether to hide the editor label and have the list take up the full width of the editor window.")]
-            public string HideLabel { get; set; }
-
-            [PreValueField("disablePreview", "Disable Preview", "boolean", Description = "Set whether to disable the preview of the items in the stack.")]
-            public string DisablePreview { get; set; }
-
-            public override IDictionary<string, object> ConvertDbToEditor(IDictionary<string, object> defaultPreVals, PreValueCollection persistedPreVals)
-            {
-                if (persistedPreVals.IsDictionaryBased)
-                {
-                    var dict = persistedPreVals.PreValuesAsDictionary;
-                    if (dict.TryGetValue("contentTypes", out PreValue contentTypes) && string.IsNullOrWhiteSpace(contentTypes.Value) == false)
-                    {
-                        var items = JArray.Parse(contentTypes.Value);
-                        if (TryEnsureContentTypeGuids(items, ApplicationContext.Current.Services.ContentTypeService))
-                        {
-                            contentTypes.Value = items.ToString();
-                        }
-                    }
-                }
-
-                return base.ConvertDbToEditor(defaultPreVals, persistedPreVals);
-            }
-        }
-
-        #endregion
-
-        #region Value Editor
-
-        protected override PropertyValueEditor CreateValueEditor()
-        {
-            return new StackedContentPropertyValueEditor(base.CreateValueEditor());
-        }
-
-        internal class StackedContentPropertyValueEditor : SimpleInnerContentPropertyValueEditor
-        {
-            public StackedContentPropertyValueEditor(PropertyValueEditor wrapped)
-                : base(wrapped)
-            { }
-
-            public override object ConvertDbToEditor(Property property, PropertyType propertyType, IDataTypeService dataTypeService)
-            {
-                if (property.Value == null)
-                    return string.Empty;
-
-                var propertyValue = property.Value.ToString();
-                if (string.IsNullOrWhiteSpace(propertyValue))
-                    return string.Empty;
-
-                var value = JsonConvert.DeserializeObject<JToken>(propertyValue);
-                if (value is JArray items)
-                {
-                    if (TryEnsureContentTypeGuids(items, ApplicationContext.Current.Services.ContentTypeService))
-                    {
-                        property.Value = items.ToString();
-                    }
-                }
-
-                return base.ConvertDbToEditor(property, propertyType, dataTypeService);
-            }
-        }
-
-        #endregion
+            : base()
+        { }
     }
 }

--- a/src/Our.Umbraco.StackedContent/PropertyEditors/StackedContentPropertyEditor.cs
+++ b/src/Our.Umbraco.StackedContent/PropertyEditors/StackedContentPropertyEditor.cs
@@ -10,6 +10,33 @@ namespace Our.Umbraco.StackedContent.PropertyEditors
 
         public StackedContentPropertyEditor()
             : base()
-        { }
+        {
+            DefaultPreValues.Add("maxItems", 0);
+            DefaultPreValues.Add("singleItemMode", "0");
+            DefaultPreValues.Add("disablePreview", "0");
+        }
+
+        protected override PreValueEditor CreatePreValueEditor()
+        {
+            return new StackedContentPreValueEditor();
+        }
+
+        internal class StackedContentPreValueEditor : SimpleInnerContentPreValueEditor
+        {
+            [PreValueField("contentTypes", "Content Types", "~/App_Plugins/InnerContent/views/innercontent.doctypepicker.html", Description = "Select the content types to use as the data blueprint.")]
+            public new string[] ContentTypes { get; set; }
+
+            [PreValueField("maxItems", "Max Items", "number", Description = "Set the maximum number of items allowed in this stack.")]
+            public string MaxItems { get; set; }
+
+            [PreValueField("singleItemMode", "Single Item Mode", "boolean", Description = "Set whether to work in single item mode (only the first defined Content Type will be used).")]
+            public string SingleItemMode { get; set; }
+
+            [PreValueField("hideLabel", "Hide Label", "boolean", Description = "Set whether to hide the editor label and have the list take up the full width of the editor window.")]
+            public string HideLabel { get; set; }
+
+            [PreValueField("disablePreview", "Disable Preview", "boolean", Description = "Set whether to disable the preview of the items in the stack.")]
+            public string DisablePreview { get; set; }
+        }
     }
 }

--- a/src/Our.Umbraco.StackedContent/Web/UI/App_Plugins/StackedContent/js/stackedcontent.controllers.js
+++ b/src/Our.Umbraco.StackedContent/Web/UI/App_Plugins/StackedContent/js/stackedcontent.controllers.js
@@ -12,11 +12,6 @@
         $scope.prompts = {};
         $scope.model.value = $scope.model.value || [];
 
-        // Sometimes changes in Inner Content require
-        // the stored models to be updated so we pass 
-        // the models through to be pre processed
-        innerContentService.preProcessModels($scope.model.value, $scope.model.config.contentTypes);
-
         $scope.canAdd = function () {
             return (!$scope.model.config.maxItems || $scope.model.config.maxItems == 0 || $scope.model.value.length < $scope.model.config.maxItems) && $scope.model.config.singleItemMode != "1";
         }

--- a/src/Our.Umbraco.StackedContent/packages.config
+++ b/src/Our.Umbraco.StackedContent/packages.config
@@ -27,7 +27,7 @@
   <package id="MiniProfiler" version="2.1.0" targetFramework="net452" />
   <package id="MySql.Data" version="6.9.9" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net452" />
-  <package id="Our.Umbraco.InnerContent.Core" version="1.0.3" targetFramework="net452" />
+  <package id="Our.Umbraco.InnerContent.Core" version="1.1.0" targetFramework="net452" />
   <package id="Owin" version="1.0" targetFramework="net452" />
   <package id="semver" version="1.1.2" targetFramework="net452" />
   <package id="SharpZipLib" version="0.86.0" targetFramework="net452" />


### PR DESCRIPTION
This is an attempt to work towards further backwards-compatibility for the alias/GUID migration.

We override the `ConvertDbToEditor` methods (in both prevalue-editor and property-editor),
and check if the "icContentTypeGuid" value is available, if not, we attempt to get the GUID, based on the alias.

To note, this PR wont compile (and the AppVeyor CI build will fail), until InnerContent's PR, https://github.com/umco/umbraco-inner-content/pull/15 has been merged in, and new version released.

---

This is intended as an alternative solution to PR #30