### PR TITLE
Preview on unpublished page

### DIFF
--- a/src/Our.Umbraco.StackedContent/Models/UnpublishedContent.cs
+++ b/src/Our.Umbraco.StackedContent/Models/UnpublishedContent.cs
@@ -1,0 +1,129 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Umbraco.Core;
+using Umbraco.Core.Models;
+using Umbraco.Core.Models.PublishedContent;
+using Umbraco.Core.PropertyEditors;
+using Umbraco.Core.Services;
+using Umbraco.Web.Models;
+
+namespace Our.Umbraco.StackedContent.Models
+{
+    internal class UnpublishedContent : PublishedContentWithKeyBase
+    {
+        private readonly IContent content;
+        private readonly Lazy<PublishedContentType> contentType;
+        private readonly Lazy<string> creatorName;
+        private readonly Lazy<string> urlName;
+        private readonly Lazy<string> writerName;
+        private readonly IPublishedProperty[] properties;
+
+        public UnpublishedContent(IContent content)
+            : base()
+        {
+            Mandate.ParameterNotNull(content, nameof(content));
+
+            var userService = new Lazy<IUserService>(() => ApplicationContext.Current.Services.UserService);
+
+            this.content = content;
+            this.contentType = new Lazy<PublishedContentType>(() => PublishedContentType.Get(this.ItemType, this.DocumentTypeAlias));
+            this.creatorName = new Lazy<string>(() => this.content.GetCreatorProfile(userService.Value).Name);
+            this.urlName = new Lazy<string>(() => this.content.Name.ToUrlSegment());
+            this.writerName = new Lazy<string>(() => this.content.GetWriterProfile(userService.Value).Name);
+
+            // TODO: Implement the IContent properties! [LK:2018-02-28]
+            this.properties = MapProperties(
+                this.contentType.Value.PropertyTypes,
+                this.content.Properties,
+                (t, v) => new UnpublishedProperty(t, v, true)).ToArray();
+        }
+
+        public override Guid Key => this.content.Key;
+
+        public override PublishedItemType ItemType => PublishedItemType.Content;
+
+        public override int Id => this.content.Id;
+
+        public override int TemplateId => this.content.Template?.Id ?? default(int);
+
+        public override int SortOrder => this.content.SortOrder;
+
+        public override string Name => this.content.Name;
+
+        public override string UrlName => this.urlName.Value;
+
+        public override string DocumentTypeAlias => this.content.ContentType?.Alias;
+
+        public override int DocumentTypeId => this.content.ContentType?.Id ?? default(int);
+
+        public override string WriterName => this.writerName.Value;
+
+        public override string CreatorName => this.creatorName.Value;
+
+        public override int WriterId => this.content.WriterId;
+
+        public override int CreatorId => this.content.CreatorId;
+
+        public override string Path => this.content.Path;
+
+        public override DateTime CreateDate => this.content.CreateDate;
+
+        public override DateTime UpdateDate => this.content.UpdateDate;
+
+        public override Guid Version => this.content.Version;
+
+        public override int Level => this.content.Level;
+
+        public override bool IsDraft => true;
+
+        public override IPublishedContent Parent => new UnpublishedContent(this.content.Parent());
+
+        public override IEnumerable<IPublishedContent> Children => this.content.Children().Select(x => new UnpublishedContent(x));
+
+        public override PublishedContentType ContentType => this.contentType.Value;
+
+        public override ICollection<IPublishedProperty> Properties => this.properties;
+
+        public override IPublishedProperty GetProperty(string alias)
+        {
+            return this.properties.FirstOrDefault(x => x.PropertyTypeAlias.InvariantEquals(alias));
+        }
+
+        private static IEnumerable<IPublishedProperty> MapProperties(
+            IEnumerable<PublishedPropertyType> propertyTypes,
+            IEnumerable<Property> properties,
+            Func<PublishedPropertyType, object, IPublishedProperty> map)
+        {
+            var propertyEditorResolver = PropertyEditorResolver.Current;
+            var dataTypeService = ApplicationContext.Current.Services.DataTypeService;
+
+            return propertyTypes.Select(x =>
+            {
+                var p = properties.SingleOrDefault(xx => xx.Alias == x.PropertyTypeAlias);
+                var v = p == null || p.Value == null ? null : p.Value;
+                if (v != null)
+                {
+                    var e = propertyEditorResolver.GetByAlias(x.PropertyEditorAlias);
+
+                    // We are converting to string, even for database values which are integer or
+                    // DateTime, which is not optimum. Doing differently would require that we have a way to tell
+                    // whether the conversion to XML string changes something or not... which we don't, and we
+                    // don't want to implement it as PropertyValueEditor.ConvertDbToXml/String should die anyway.
+
+                    // Don't think about improving the situation here: this is a corner case and the real
+                    // thing to do is to get rig of PropertyValueEditor.ConvertDbToXml/String.
+
+                    // Use ConvertDbToString to keep it simple, although everywhere we use ConvertDbToXml and
+                    // nothing ensures that the two methods are consistent.
+                    if (e != null)
+                    {
+                        v = e.ValueEditor.ConvertDbToString(p, p.PropertyType, dataTypeService);
+                    }
+                }
+
+                return map(x, v);
+            });
+        }
+    }
+}

--- a/src/Our.Umbraco.StackedContent/Models/UnpublishedContent.cs
+++ b/src/Our.Umbraco.StackedContent/Models/UnpublishedContent.cs
@@ -17,6 +17,8 @@ namespace Our.Umbraco.StackedContent.Models
         private readonly Lazy<string> creatorName;
         private readonly Lazy<string> urlName;
         private readonly Lazy<string> writerName;
+        private readonly Lazy<IPublishedContent> parent;
+        private readonly Lazy<IEnumerable<IPublishedContent>> children;
         private readonly IPublishedProperty[] properties;
 
         public UnpublishedContent(IContent content)
@@ -31,6 +33,8 @@ namespace Our.Umbraco.StackedContent.Models
             this.creatorName = new Lazy<string>(() => this.content.GetCreatorProfile(userService.Value).Name);
             this.urlName = new Lazy<string>(() => this.content.Name.ToUrlSegment());
             this.writerName = new Lazy<string>(() => this.content.GetWriterProfile(userService.Value).Name);
+            this.parent = new Lazy<IPublishedContent>(() => new UnpublishedContent(this.content.Parent()));
+            this.children = new Lazy<IEnumerable<IPublishedContent>>(() => this.content.Children().Select(x => new UnpublishedContent(x)));
 
             // TODO: Implement the IContent properties! [LK:2018-02-28]
             this.properties = MapProperties(
@@ -77,9 +81,9 @@ namespace Our.Umbraco.StackedContent.Models
 
         public override bool IsDraft => true;
 
-        public override IPublishedContent Parent => new UnpublishedContent(this.content.Parent());
+        public override IPublishedContent Parent => this.parent.Value;
 
-        public override IEnumerable<IPublishedContent> Children => this.content.Children().Select(x => new UnpublishedContent(x));
+        public override IEnumerable<IPublishedContent> Children => this.children.Value;
 
         public override PublishedContentType ContentType => this.contentType.Value;
 

--- a/src/Our.Umbraco.StackedContent/Models/UnpublishedContent.cs
+++ b/src/Our.Umbraco.StackedContent/Models/UnpublishedContent.cs
@@ -36,7 +36,7 @@ namespace Our.Umbraco.StackedContent.Models
 
             this.content = content;
 
-            this.children = new Lazy<IEnumerable<IPublishedContent>>(() => this.content.Children().Select(x => new UnpublishedContent(x, serviceContext)));
+            this.children = new Lazy<IEnumerable<IPublishedContent>>(() => this.content.Children().Select(x => new UnpublishedContent(x, serviceContext)).ToList());
             this.contentType = new Lazy<PublishedContentType>(() => PublishedContentType.Get(this.ItemType, this.DocumentTypeAlias));
             this.creatorName = new Lazy<string>(() => this.content.GetCreatorProfile(userService.Value).Name);
             this.parent = new Lazy<IPublishedContent>(() => new UnpublishedContent(this.content.Parent(), serviceContext));

--- a/src/Our.Umbraco.StackedContent/Models/UnpublishedContent.cs
+++ b/src/Our.Umbraco.StackedContent/Models/UnpublishedContent.cs
@@ -13,13 +13,12 @@ namespace Our.Umbraco.StackedContent.Models
     internal class UnpublishedContent : PublishedContentWithKeyBase
     {
         private readonly IContent content;
-        private readonly ServiceContext serviceContext;
 
         private readonly Lazy<IEnumerable<IPublishedContent>> children;
         private readonly Lazy<PublishedContentType> contentType;
         private readonly Lazy<string> creatorName;
         private readonly Lazy<IPublishedContent> parent;
-        private readonly IPublishedProperty[] properties;
+        private readonly Lazy<Dictionary<string, IPublishedProperty>> properties;
         private readonly Lazy<string> urlName;
         private readonly Lazy<string> writerName;
 
@@ -36,20 +35,14 @@ namespace Our.Umbraco.StackedContent.Models
             var userService = new Lazy<IUserService>(() => serviceContext.UserService);
 
             this.content = content;
-            this.serviceContext = serviceContext;
 
             this.children = new Lazy<IEnumerable<IPublishedContent>>(() => this.content.Children().Select(x => new UnpublishedContent(x, serviceContext)));
             this.contentType = new Lazy<PublishedContentType>(() => PublishedContentType.Get(this.ItemType, this.DocumentTypeAlias));
             this.creatorName = new Lazy<string>(() => this.content.GetCreatorProfile(userService.Value).Name);
             this.parent = new Lazy<IPublishedContent>(() => new UnpublishedContent(this.content.Parent(), serviceContext));
+            this.properties = new Lazy<Dictionary<string, IPublishedProperty>>(() => MapProperties(PropertyEditorResolver.Current, serviceContext));
             this.urlName = new Lazy<string>(() => this.content.Name.ToUrlSegment());
             this.writerName = new Lazy<string>(() => this.content.GetWriterProfile(userService.Value).Name);
-
-            // TODO: Refactor `MapProperties` [LK:2018-03-05]
-            this.properties = MapProperties(
-                this.contentType.Value.PropertyTypes,
-                this.content.Properties,
-                (t, v) => new UnpublishedProperty(t, v, true)).ToArray();
         }
 
         public override Guid Key => this.content.Key;
@@ -96,47 +89,37 @@ namespace Our.Umbraco.StackedContent.Models
 
         public override PublishedContentType ContentType => this.contentType.Value;
 
-        public override ICollection<IPublishedProperty> Properties => this.properties;
+        public override ICollection<IPublishedProperty> Properties => this.properties.Value.Values;
 
         public override IPublishedProperty GetProperty(string alias)
         {
-            return this.properties.FirstOrDefault(x => x.PropertyTypeAlias.InvariantEquals(alias));
+            return this.properties.Value.TryGetValue(alias, out IPublishedProperty property) ? property : null;
         }
 
-        private IEnumerable<IPublishedProperty> MapProperties(
-            IEnumerable<PublishedPropertyType> propertyTypes,
-            IEnumerable<Property> properties,
-            Func<PublishedPropertyType, object, IPublishedProperty> map)
+        private Dictionary<string, IPublishedProperty> MapProperties(PropertyEditorResolver resolver, ServiceContext services)
         {
-            var propertyEditorResolver = PropertyEditorResolver.Current;
-            var dataTypeService = this.serviceContext.DataTypeService;
+            var contentType = this.contentType.Value;
+            var properties = this.content.Properties;
 
-            return propertyTypes.Select(x =>
+            var items = new Dictionary<string, IPublishedProperty>(StringComparer.InvariantCultureIgnoreCase);
+
+            foreach (var propertyType in contentType.PropertyTypes)
             {
-                var p = properties.SingleOrDefault(xx => xx.Alias == x.PropertyTypeAlias);
-                var v = p == null || p.Value == null ? null : p.Value;
-                if (v != null)
+                var property = properties.FirstOrDefault(x => x.Alias.InvariantEquals(propertyType.PropertyTypeAlias));
+                var value = property?.Value;
+                if (value != null)
                 {
-                    var e = propertyEditorResolver.GetByAlias(x.PropertyEditorAlias);
-
-                    // We are converting to string, even for database values which are integer or
-                    // DateTime, which is not optimum. Doing differently would require that we have a way to tell
-                    // whether the conversion to XML string changes something or not... which we don't, and we
-                    // don't want to implement it as PropertyValueEditor.ConvertDbToXml/String should die anyway.
-
-                    // Don't think about improving the situation here: this is a corner case and the real
-                    // thing to do is to get rig of PropertyValueEditor.ConvertDbToXml/String.
-
-                    // Use ConvertDbToString to keep it simple, although everywhere we use ConvertDbToXml and
-                    // nothing ensures that the two methods are consistent.
-                    if (e != null)
+                    var propertyEditor = resolver.GetByAlias(propertyType.PropertyEditorAlias);
+                    if (propertyEditor != null)
                     {
-                        v = e.ValueEditor.ConvertDbToString(p, p.PropertyType, dataTypeService);
+                        value = propertyEditor.ValueEditor.ConvertDbToString(property, property.PropertyType, services.DataTypeService);
                     }
                 }
 
-                return map(x, v);
-            });
+                items.Add(propertyType.PropertyTypeAlias, new UnpublishedProperty(propertyType, value));
+            }
+
+            return items;
         }
     }
 }

--- a/src/Our.Umbraco.StackedContent/Models/UnpublishedProperty.cs
+++ b/src/Our.Umbraco.StackedContent/Models/UnpublishedProperty.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using Umbraco.Core.Models;
+using Umbraco.Core.Models.PublishedContent;
+
+namespace Our.Umbraco.StackedContent.Models
+{
+    internal class UnpublishedProperty : IPublishedProperty
+    {
+        private readonly PublishedPropertyType propertyType;
+        private readonly object rawValue;
+        private readonly Lazy<object> sourceValue;
+        private readonly Lazy<object> objectValue;
+        private readonly Lazy<object> xpathValue;
+        private readonly bool isPreview;
+
+        public UnpublishedProperty(PublishedPropertyType propertyType, object value)
+            : this(propertyType, value, false)
+        { }
+
+        public UnpublishedProperty(PublishedPropertyType propertyType, object value, bool isPreview)
+        {
+            this.propertyType = propertyType;
+            this.isPreview = isPreview;
+
+            this.rawValue = value;
+
+            this.sourceValue = new Lazy<object>(() => this.propertyType.ConvertDataToSource(this.rawValue, this.isPreview));
+            this.objectValue = new Lazy<object>(() => this.propertyType.ConvertSourceToObject(this.sourceValue.Value, this.isPreview));
+            this.xpathValue = new Lazy<object>(() => this.propertyType.ConvertSourceToXPath(this.sourceValue.Value, this.isPreview));
+        }
+
+        public string PropertyTypeAlias => this.propertyType.PropertyTypeAlias;
+
+        public bool HasValue => this.DataValue != null && this.DataValue.ToString().Trim().Length > 0;
+
+        public object DataValue => this.rawValue;
+
+        public object Value => this.objectValue.Value;
+
+        public object XPathValue => this.xpathValue.Value;
+    }
+}

--- a/src/Our.Umbraco.StackedContent/Models/UnpublishedProperty.cs
+++ b/src/Our.Umbraco.StackedContent/Models/UnpublishedProperty.cs
@@ -7,33 +7,29 @@ namespace Our.Umbraco.StackedContent.Models
     internal class UnpublishedProperty : IPublishedProperty
     {
         private readonly PublishedPropertyType propertyType;
-        private readonly object rawValue;
+        private readonly object dataValue;
+        private readonly Lazy<bool> hasValue;
         private readonly Lazy<object> sourceValue;
         private readonly Lazy<object> objectValue;
         private readonly Lazy<object> xpathValue;
-        private readonly bool isPreview;
 
         public UnpublishedProperty(PublishedPropertyType propertyType, object value)
-            : this(propertyType, value, false)
-        { }
-
-        public UnpublishedProperty(PublishedPropertyType propertyType, object value, bool isPreview)
         {
             this.propertyType = propertyType;
-            this.isPreview = isPreview;
 
-            this.rawValue = value;
+            this.dataValue = value;
+            this.hasValue = new Lazy<bool>(() => value != null && value.ToString().Trim().Length > 0);
 
-            this.sourceValue = new Lazy<object>(() => this.propertyType.ConvertDataToSource(this.rawValue, this.isPreview));
-            this.objectValue = new Lazy<object>(() => this.propertyType.ConvertSourceToObject(this.sourceValue.Value, this.isPreview));
-            this.xpathValue = new Lazy<object>(() => this.propertyType.ConvertSourceToXPath(this.sourceValue.Value, this.isPreview));
+            this.sourceValue = new Lazy<object>(() => this.propertyType.ConvertDataToSource(this.dataValue, true));
+            this.objectValue = new Lazy<object>(() => this.propertyType.ConvertSourceToObject(this.sourceValue.Value, true));
+            this.xpathValue = new Lazy<object>(() => this.propertyType.ConvertSourceToXPath(this.sourceValue.Value, true));
         }
 
         public string PropertyTypeAlias => this.propertyType.PropertyTypeAlias;
 
-        public bool HasValue => this.DataValue != null && this.DataValue.ToString().Trim().Length > 0;
+        public bool HasValue => this.hasValue.Value;
 
-        public object DataValue => this.rawValue;
+        public object DataValue => this.dataValue;
 
         public object Value => this.objectValue.Value;
 

--- a/src/Our.Umbraco.StackedContent/Our.Umbraco.StackedContent.csproj
+++ b/src/Our.Umbraco.StackedContent/Our.Umbraco.StackedContent.csproj
@@ -258,6 +258,8 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Converters\StackedContentValueConverter.cs" />
+    <Compile Include="Models\UnpublishedContent.cs" />
+    <Compile Include="Models\UnpublishedProperty.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\VersionInfo.cs" />
     <Compile Include="PropertyEditors\StackedContentPropertyEditor.cs" />

--- a/src/Our.Umbraco.StackedContent/Web/Controllers/StackedContentApiController.cs
+++ b/src/Our.Umbraco.StackedContent/Web/Controllers/StackedContentApiController.cs
@@ -1,8 +1,10 @@
 ﻿using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Net.Mime;
 using System.Web.Http;
 using Newtonsoft.Json.Linq;
 using Our.Umbraco.InnerContent.Helpers;
+using Our.Umbraco.StackedContent.Models;
 using Our.Umbraco.StackedContent.Web.Helpers;
 using Umbraco.Web.Mvc;
 using Umbraco.Web.WebApi;
@@ -16,8 +18,12 @@ namespace Our.Umbraco.StackedContent.Web.Controllers
         public HttpResponseMessage GetPreviewMarkup([FromBody] JObject item, int parentId)
         {
             // Get parent to container node
-            //TODO: Convert IContent if no published content?
             var parent = UmbracoContext.ContentCache.GetById(parentId);
+            if (parent == null)
+            {
+                // If unpublished, then get the IContent and convert to fake PublishedContent
+                parent = new UnpublishedContent(Services.ContentService.GetById(parentId));
+            }
 
             // Convert item
             var content = InnerContentHelper.ConvertInnerContentToPublishedContent(item, parent);
@@ -38,7 +44,7 @@ namespace Our.Umbraco.StackedContent.Web.Controllers
                 Content = new StringContent(markup ?? string.Empty)
             };
 
-            response.Content.Headers.ContentType = new MediaTypeHeaderValue("text/html");
+            response.Content.Headers.ContentType = new MediaTypeHeaderValue(MediaTypeNames.Text.Html);
 
             return response;
         }

--- a/src/Our.Umbraco.StackedContent/Web/Controllers/StackedContentApiController.cs
+++ b/src/Our.Umbraco.StackedContent/Web/Controllers/StackedContentApiController.cs
@@ -22,7 +22,7 @@ namespace Our.Umbraco.StackedContent.Web.Controllers
             if (page == null)
             {
                 // If unpublished, then fake PublishedContent (with IContent object)
-                page = new UnpublishedContent(Services.ContentService.GetById(pageId));
+                page = new UnpublishedContent(pageId, Services);
             }
 
             // Convert item

--- a/src/Our.Umbraco.StackedContent/Web/Controllers/StackedContentApiController.cs
+++ b/src/Our.Umbraco.StackedContent/Web/Controllers/StackedContentApiController.cs
@@ -15,21 +15,21 @@ namespace Our.Umbraco.StackedContent.Web.Controllers
     public class StackedContentApiController : UmbracoAuthorizedApiController
     {
         [HttpPost]
-        public HttpResponseMessage GetPreviewMarkup([FromBody] JObject item, int parentId)
+        public HttpResponseMessage GetPreviewMarkup([FromBody] JObject item, int pageId)
         {
-            // Get parent to container node
-            var parent = UmbracoContext.ContentCache.GetById(parentId);
-            if (parent == null)
+            // Get page container node
+            var page = UmbracoContext.ContentCache.GetById(pageId);
+            if (page == null)
             {
-                // If unpublished, then get the IContent and convert to fake PublishedContent
-                parent = new UnpublishedContent(Services.ContentService.GetById(parentId));
+                // If unpublished, then fake PublishedContent (with IContent object)
+                page = new UnpublishedContent(Services.ContentService.GetById(pageId));
             }
 
             // Convert item
-            var content = InnerContentHelper.ConvertInnerContentToPublishedContent(item, parent);
+            var content = InnerContentHelper.ConvertInnerContentToPublishedContent(item, page);
 
             // Construct preview model
-            var model = new PreviewModel { Page = parent, Item = content };
+            var model = new PreviewModel { Page = page, Item = content };
 
             // Render view
             var markup = ViewHelper.RenderPartial(content.DocumentTypeAlias, model, new[]

--- a/src/Our.Umbraco.StackedContent/Web/UI/App_Plugins/StackedContent/js/stackedcontent.resources.js
+++ b/src/Our.Umbraco.StackedContent/Web/UI/App_Plugins/StackedContent/js/stackedcontent.resources.js
@@ -1,12 +1,12 @@
 ﻿angular.module('umbraco.resources').factory('Our.Umbraco.StackedContent.Resources.StackedContentResources',
     function ($q, $http, umbRequestHelper) {
         return {
-            getPreviewMarkup: function (data, parentId) {
+            getPreviewMarkup: function (data, pageId) {
                 return umbRequestHelper.resourcePromise(
                     $http({
                         url: "/umbraco/backoffice/StackedContent/StackedContentApi/GetPreviewMarkup",
                         method: "POST",
-                        params: { parentId: parentId },
+                        params: { pageId: pageId },
                         data: data
                     }),
                     'Failed to retrieve preview markup'


### PR DESCRIPTION
> @mattbrailsford - This was more of an "itch-scratching" exercise.

Added an `UnpublishedContent` model as a proxy for the raw `IContent` object/data.
Meaning that preview partial-views could have access to unpublished content properties.

> Not a direct copy, but with reference to Jeroen's gist: https://gist.github.com/jbreuer/dde3605035179c34b7287850c45cb8c9