### PR TITLE
Decrease z-index of .stack__item

### DIFF
--- a/src/Our.Umbraco.StackedContent/Web/UI/App_Plugins/StackedContent/css/stackedcontent.css
+++ b/src/Our.Umbraco.StackedContent/Web/UI/App_Plugins/StackedContent/css/stackedcontent.css
@@ -14,7 +14,7 @@
     position: relative;
     display: block;
     margin: 0;
-    z-index: 10;
+    z-index: 9;
 }
 
 .stack__preview-wrapper {


### PR DESCRIPTION
Ensures that Stacked Content does not overlap tab overflow menu.