### PR TITLE
Added toggles to collapse stacked content in backoffice

### DIFF
--- a/src/Our.Umbraco.StackedContent/Web/UI/App_Plugins/StackedContent/css/stackedcontent.css
+++ b/src/Our.Umbraco.StackedContent/Web/UI/App_Plugins/StackedContent/css/stackedcontent.css
@@ -28,6 +28,10 @@
     display: block;
 }
 
+.stack__preview-toggle.active h4:after {
+    transform:  rotate(-90deg);
+}
+
 .stack__preview-toggle:hover {
     cursor: pointer;
 }

--- a/src/Our.Umbraco.StackedContent/Web/UI/App_Plugins/StackedContent/css/stackedcontent.css
+++ b/src/Our.Umbraco.StackedContent/Web/UI/App_Plugins/StackedContent/css/stackedcontent.css
@@ -22,6 +22,39 @@
     border: 1px solid #f8f8f8;
 }
 
+.stack__preview-toggle {
+    border-bottom: 1px solid #f8f8f8;
+    padding: 10px 15px;
+    display: block;
+}
+
+.stack__preview-toggle:hover {
+    cursor: pointer;
+}
+
+.stack__preview-toggle h4 {
+    display: inline-block;
+    margin: 0;
+}
+
+.stack__preview-toggle h4:after {
+    content: "\e12b";
+    display: inline-block;
+    font-family: icomoon;
+    font-weight: 400;
+    font-style: normal;
+    text-decoration: inherit;
+    -webkit-font-smoothing: antialiased;
+    transform: rotate(90deg);
+    margin-left: 10px;
+    font-size: 12px;
+}
+
+.stack__preview--close {
+    max-height: 0;
+    overflow: hidden;
+}
+
 .stacked-content .placeholder,
 .stack__preview {
     display: block;

--- a/src/Our.Umbraco.StackedContent/Web/UI/App_Plugins/StackedContent/js/stackedcontent.js
+++ b/src/Our.Umbraco.StackedContent/Web/UI/App_Plugins/StackedContent/js/stackedcontent.js
@@ -58,6 +58,10 @@ angular.module("umbraco").controller("Our.Umbraco.StackedContent.Controllers.Sta
             setDirty();
         };
 
+        $scope.toggleContent = function (evt, itm) {
+            itm.isClosed = !itm.isClosed
+        }
+
         $scope.copyContent = function (evt, idx) {
             var item = JSON.parse(JSON.stringify($scope.model.value[idx]));
             var success = innerContentService.setCopiedContent(item);

--- a/src/Our.Umbraco.StackedContent/Web/UI/App_Plugins/StackedContent/views/stackedcontent.html
+++ b/src/Our.Umbraco.StackedContent/Web/UI/App_Plugins/StackedContent/views/stackedcontent.html
@@ -23,7 +23,7 @@
                             <i class="icon {{itm.icon}}"></i>
                             <h3>{{itm.name}}</h3>
                         </div>
-                        <div class="stack__preview-toggle" ng-click="toggleContent($event, itm)" ng-if="markup[itm.key]">
+                        <div class="stack__preview-toggle" ng-class="{ 'active': itm.isClosed }" ng-click="toggleContent($event, itm)" ng-if="markup[itm.key]">
                             <h4>{{itm.name}}</h4>
                         </div>
                         <div ng-click="editContent($event, $index, itm)" class="stack__preview" ng-if="markup[itm.key]">

--- a/src/Our.Umbraco.StackedContent/Web/UI/App_Plugins/StackedContent/views/stackedcontent.html
+++ b/src/Our.Umbraco.StackedContent/Web/UI/App_Plugins/StackedContent/views/stackedcontent.html
@@ -23,6 +23,9 @@
                             <i class="icon {{itm.icon}}"></i>
                             <h3>{{itm.name}}</h3>
                         </div>
+                        <div class="stack__preview-toggle" ng-click="toggleContent($event, itm)" ng-if="markup[itm.key]">
+                            <h4>{{itm.name}}</h4>
+                        </div>
                         <div ng-click="editContent($event, $index, itm)" class="stack__preview" ng-if="markup[itm.key]">
                             <div ng-bind-html-unsafe="markup[itm.key]"></div>
                         </div>


### PR DESCRIPTION
Messaged Matt on Twitter about this. 
We have clients who like to preview styled markup in the back-office (rather than hitting preview button), some of these components can render large, making reordering a pain.

This toggle only shows when views are rendered as markup and allows the user to collapse each component to reorder.  