### PR TITLE
Create published Content Request prior to Rendering to support macros…

### DIFF
--- a/src/Our.Umbraco.StackedContent/Our.Umbraco.StackedContent.csproj
+++ b/src/Our.Umbraco.StackedContent/Our.Umbraco.StackedContent.csproj
@@ -43,7 +43,9 @@
       <Private>False</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Web" />
+    <Reference Include="System.Web.ApplicationServices" />
     <Reference Include="System.Web.Http, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.AspNet.WebApi.Core.5.2.3\lib\net45\System.Web.Http.dll</HintPath>
       <Private>False</Private>

--- a/src/Our.Umbraco.StackedContent/Web/Controllers/StackedContentApiController.cs
+++ b/src/Our.Umbraco.StackedContent/Web/Controllers/StackedContentApiController.cs
@@ -1,13 +1,18 @@
-﻿using System.Net.Http;
+﻿using System;
+using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Net.Mime;
+using System.Web;
 using System.Web.Http;
+using System.Web.Security;
 using Newtonsoft.Json.Linq;
 using Our.Umbraco.InnerContent.Helpers;
 using Our.Umbraco.StackedContent.Models;
 using Our.Umbraco.StackedContent.Web.Helpers;
+using Umbraco.Core.Configuration;
 using Umbraco.Core.Models;
 using Umbraco.Web.Mvc;
+using Umbraco.Web.Routing;
 using Umbraco.Web.WebApi;
 
 namespace Our.Umbraco.StackedContent.Web.Controllers
@@ -30,6 +35,22 @@ namespace Our.Umbraco.StackedContent.Web.Controllers
                     // If unpublished, then fake PublishedContent (with IContent object)
                     page = new UnpublishedContent(pageId, Services);
                 }
+
+                var baseUrl = HttpContext.Current.Request.Url.AbsoluteUri.Replace(HttpContext.Current.Request.Path, "/");
+                var umbUrl = baseUrl + page.Url.TrimStart('/');
+
+                var pcr = new PublishedContentRequest(
+                    new Uri(umbUrl),
+                    UmbracoContext.RoutingContext,
+                    UmbracoConfig.For.UmbracoSettings().WebRouting,
+                    s => Roles.Provider.GetRolesForUser(s)
+                );
+
+                UmbracoContext.PublishedContentRequest = pcr;
+                UmbracoContext.PublishedContentRequest.PublishedContent = page;
+
+                pcr.Prepare();
+
             }
 
             // Convert item


### PR DESCRIPTION
Added code based on https://github.com/umbraco/Umbraco-CMS/blob/dev-v7/src/Umbraco.Web/Mvc/EnsurePublishedContentRequestAttribute.cs to create a PublishContentRequest prior to rendering the preview content. This will allow Macros to be rendered in a Rich Text Editor
